### PR TITLE
Net install hide installed content option

### DIFF
--- a/include/ui/netInstPage.hpp
+++ b/include/ui/netInstPage.hpp
@@ -21,12 +21,14 @@ namespace inst::ui {
             std::vector<std::string> ourUrls;
             std::vector<std::string> selectedUrls;
             std::vector<std::string> alternativeNames;
+            std::vector<std::pair<u64, u32>> installedTitles;
             TextBlock::Ref butText;
             Rectangle::Ref topRect;
             Rectangle::Ref infoRect;
             Rectangle::Ref botRect;
             pu::ui::elm::Menu::Ref menu;
             Image::Ref infoImage;
+            void listInstalledTitles();
             void drawMenuItems(bool clearItems);
             void selectTitle(int selectedIndex);
     };

--- a/romfs/lang/en.json
+++ b/romfs/lang/en.json
@@ -62,7 +62,8 @@
             "transfer_interput": "An error occured during data transfer. Check your network connection.",
             "source_string": " over local network",
             "buttons": "\ue0e3 Install Over Internet    \ue0f0 Install From HTTP Directory    \ue0e2 Help    \ue0e1 Cancel",
-            "buttons1": "\ue0e0 Select File    \ue0e3 Select All    \ue0ef Install File(s)    \ue0e1 Cancel"
+            "buttons1": "\ue0e0 Select File    \ue0e3 Select All    \ue0ef Install File(s)    \ue0e2 Hide Installed    \ue0e1 Cancel",
+            "buttons1_show": "\ue0e0 Select File    \ue0e3 Select All    \ue0ef Install File(s)    \ue0e2 Show Installed    \ue0e1 Cancel"
         },
         "sd": {
             "help": {

--- a/source/util/util.cpp
+++ b/source/util/util.cpp
@@ -16,6 +16,7 @@
 #include "util/usb_comms_awoo.h"
 #include "util/json.hpp"
 #include "nx/usbhdd.h"
+#include "util/error.hpp"
 
 namespace inst::util {
     void initApp () {
@@ -30,9 +31,14 @@ namespace inst::util {
         awoo_usbCommsInitialize();
 
 		nx::hdd::init();
+
+        if(R_FAILED(ncmInitialize()))
+            LOG_DEBUG("Failed to initialize ncm\n");
     }
 
     void deinitApp () {
+        ncmExit();
+
 		nx::hdd::exit();
         socketExit();
         awoo_usbCommsExit();


### PR DESCRIPTION
Added an option to hide installed titles to the network install menu. Seems like a quite helpful feature for large libraries. Only implemented it for the network menu, but it would be trivial to generalize it and apply it the the other content sources, if that's desired. USB HDD could probably benefit from such an option, as well.