### PR TITLE
Align memory for encryption to not corrupt nsz files compressed with zstd 1.5.0 and later

### DIFF
--- a/source/nx/nca_writer.cpp
+++ b/source/nx/nca_writer.cpp
@@ -179,6 +179,7 @@ public:
                processChunk(m_buffer.data(), m_buffer.size());
           }
 
+          encrypt(m_deflateBuffer.data(), m_deflateBuffer.size(), m_offset);
           flush();
 
           return true;
@@ -235,41 +236,48 @@ public:
           return true;
      }
 
-     u64 processChunk(const  u8* ptr, u64 sz)
+     u64 processChunk(const u8* ptr, u64 sz)
      {
-          ZSTD_inBuffer input = { ptr, sz, 0 };
-          ZSTD_outBuffer output = { buffOut, buffOutSize, 0 };
-          m_deflateBuffer.resize(sz);
-          m_deflateBuffer.resize(0);
-
-          while (input.pos < input.size || output.pos > 0)
+          while(sz > 0)
           {
-               size_t const ret = ZSTD_decompressStream(dctx, &output, &input);
+               const size_t readChunkSz = std::min(sz, buffInSize);
+               ZSTD_inBuffer input = { ptr, readChunkSz, 0 };
 
-               if (ZSTD_isError(ret))
+               while(input.pos < input.size)
                {
-                    LOG_DEBUG("%s\n", ZSTD_getErrorName(ret));
-                    return false;
+                    ZSTD_outBuffer output = { buffOut, buffOutSize, 0 };
+                    size_t const ret = ZSTD_decompressStream(dctx, &output, &input);
+
+                    if (ZSTD_isError(ret))
+                    {
+                         LOG_DEBUG("%s\n", ZSTD_getErrorName(ret));
+                         return 0;
+                    }
+
+                    size_t len = output.pos;
+                    u8* p = (u8*)buffOut;                         
+
+                    while(len)
+                    {
+                         const size_t writeChunkSz = std::min(0x1000000 - m_deflateBuffer.size(), len);
+
+                         append(m_deflateBuffer, p, writeChunkSz);
+
+                         if(m_deflateBuffer.size() >= 0x1000000)
+                         {
+                              encrypt(m_deflateBuffer.data(), m_deflateBuffer.size(), m_offset);
+                              flush();
+                         }
+
+                         p += writeChunkSz;
+                         len -= writeChunkSz;
+                    }
                }
 
-               append(m_deflateBuffer, (const u8*)buffOut, output.pos);
-               output.pos = 0;
-
-               if (m_deflateBuffer.size() >= 0x1000000) // 16 MB
-               {
-                    encrypt(m_deflateBuffer.data(), m_deflateBuffer.size(), m_offset);
-
-                    flush();
-               }
-
+               sz -= readChunkSz;
+               ptr += readChunkSz;
           }
 
-          if (m_deflateBuffer.size())
-          {
-               encrypt(m_deflateBuffer.data(), m_deflateBuffer.size(), m_offset);
-
-               flush();
-          }
           return 1;
      }
 


### PR DESCRIPTION
The installation of NSZ games compressed with zstd 1.5.0 or later results in corrupted installations. This issue occurs due to a memory misalignment of the encrypt functions input. With zstd 1.5.0 block splitting is used for compression level 16 and higher which is what causes the memory to get unaligned. This PR fixes this memory alignment issue.

This bug got discussed in length at https://github.com/nicoboss/nsz/issues/120. All title installer with an NCA writer based on Adubbz Tinfoil are affected. This fix is based on the fix @blawar developed for Tinleaf and Tinfoil. I tested this with multiple games and it fixes the issue without any measurable performance impact. This PR fixes #34